### PR TITLE
Add support for generating go.mod from WORKSPACE

### DIFF
--- a/bzl/query.go
+++ b/bzl/query.go
@@ -96,7 +96,7 @@ func parseGoRepository(r *bzlpb.Rule) (string, ExtGoLib, error) {
 			if err != nil {
 				return "", ExtGoLib{}, err
 			}
-		case "commit", "tag":
+		case "commit", "tag", "version":
 			if commit != "" {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func writeGoMod(moduleName string, info *bzl.Info, exts map[string]bzl.ExtGoLib)
 			module.Requires = append(module.Requires, v)
 		} else {
 			dep := v
-			dep.Commit = "v0.0.0" // Unknown
+			dep.Commit = "latest" // Unknown
 			module.Requires = append(module.Requires, dep)
 			module.Replaces = append(module.Replaces, v)
 		}


### PR DESCRIPTION
Add option `-mod <module-name>`  to generate a `go.mod` file listing all the dependencies with the specified commit hash as the version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kormat/bzlcompat/2)
<!-- Reviewable:end -->
